### PR TITLE
Add new OpenShiftAsciiDoc and AsciiDoc rules

### DIFF
--- a/library.json
+++ b/library.json
@@ -52,5 +52,17 @@
         "description": "A Vale-compatible implementation of the Red Hat Supplementary Style Guide.",
         "homepage": "https://redhat-documentation.github.io/vale-at-red-hat/docs/user-guide/redhat-style-for-vale/",
         "url": "https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip"
+    },
+    {
+        "name": "AsciiDoc",
+        "description": "A Vale-compatible implementation of select AsciiDoc syntax rules.",
+        "homepage": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/user-guide/asciidoc-style-for-vale/",
+        "url": "https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/AsciiDoc.zip"
+    },
+    {
+        "name": "OpenShiftAsciiDoc",
+        "description": "A Vale-compatible implementation of select AsciiDoc guidance from the OpenShift docs contributor guidelines.",
+        "homepage": "https://redhat-documentation.github.io/vale-at-red-hat/docs/main/user-guide/openshift-asciidoc-style-for-vale/",
+        "url": "https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/OpenShiftAsciiDoc.zip"
     }
 ]


### PR DESCRIPTION
Adding new AsciiDoc and OpenShiftAsciiDoc rule sets to the list of packages.

AsciiDoc rules check for things like:

* Open attribute blocks
* Open quoted ID values
* Images and links that are missing accessibility alt tags
* Missing or incorrect callouts
* Unterminated admonition, listing, and table blocks
* Unbalanced if statements

OpenShiftDocs rules check for things like: 

* "_additional-resources" role attribute declaration
* Terminal code block missing a command prompt at the beginning of the line.
* For example output, prepend the code block with '.Example output'.
* ID missing the "_{context}" variable at the end of the ID.
* Module missing the "_content-type" variable.
* Xrefs missing an anchor ID
* Use .adoc instead of .html in xrefs
* The xref is missing link text

cc @rohennes