### PR TITLE
add new AsciiDocDITA rules

### DIFF
--- a/library.json
+++ b/library.json
@@ -118,5 +118,15 @@
         "tags": [
             "style"
         ]
+    },
+    {
+        "name": "AsciiDocDITA",
+        "description": "A Vale-compatible implementation of select DITA transformation guidelines for transforming existing AsciiDoc files into a DITA-compatible format.",
+        "homepage": "https://github.com/jhradilek/asciidoctor-dita-vale",
+        "url": "https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip",
+        "logo": "https://github.com/redhat-documentation.png",
+        "tags": [
+            "style"
+        ]
     }
 ]


### PR DESCRIPTION
this PR adds a new AsciiDocDITA rule set to the list of packages. this package attempts to find any AsciiDoc files that will not cleanly transform into DITA-compatible format so that writers can manually update those files for DITA compliance. it checks for things like the following:

- Nested sections of content (error)
- Proper content type definitions (warning)
- Cross references to files outside of the current document (warning)
- Existence of page breaks (warning)
- Lists all conditional statements in a file (suggestion)

[and more](https://github.com/jhradilek/asciidoctor-dita-vale?tab=readme-ov-file#available-rules)

we want to enable this for the openshift-docs prow CI so that we can be sure writers are not introducing anything new that would prevent transformation to DITA formatting as they continue to work on content