### PR TITLE
Adding the `neighbor` package to the official Vale library.

### DIFF
--- a/library.json
+++ b/library.json
@@ -139,10 +139,10 @@
             "style",
             "inclusive-language"
         ]
-    }
+    },
     {
     "name": "neighbor",
-    "description": "Vale prose linting rules for accessibility. Flags ableist terms, disability metaphors, English idioms, and directional layout references.",
+    "description": "Accessibility and inclusive language rules for Vale. Flags exclusionary language, ableist terms, metaphors, and complex idioms.",
     "homepage": "https://github.com/a11yfred/neighbor",
     "url": "https://github.com/a11yfred/neighbor/releases/latest/download/neighbor.zip",
     "logo": "https://github.com/a11yfred.png",
@@ -151,5 +151,6 @@
         "inclusive-language"
     ]
 }
+
 
 ]

--- a/library.json
+++ b/library.json
@@ -140,4 +140,16 @@
             "inclusive-language"
         ]
     }
+    {
+    "name": "neighbor",
+    "description": "Vale prose linting rules for accessibility. Flags ableist terms, disability metaphors, English idioms, and directional layout references.",
+    "homepage": "https://github.com/a11yfred/neighbor",
+    "url": "https://github.com/a11yfred/neighbor/releases/latest/download/neighbor.zip",
+    "logo": "https://github.com/a11yfred.png",
+    "tags": [
+        "style",
+        "inclusive-language"
+    ]
+}
+
 ]


### PR DESCRIPTION
This package is a companion to the `@a11yfred/neighbor` ESLint and Stylelint plugins. It provides prose linting rules focused on accessibility and inclusive language.

Specifically, it flags language patterns that affect readability, comprehension, and inclusion, such as:
- Ableist terms and suffering framing (SC 3.1.1)
- Disability metaphors 
- Opaque English idioms and business jargon (SC 3.1.5)
- Directional layout references (SC 1.3.3)
- ALL CAPS prose
- Bare ampersands