### PR TITLE
Add ClearProse

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,6 +10,16 @@
         ]
     },
     {
+        "name": "ClearProse",
+        "description": "Prohibits em dashes in reStructuredText prose, without reporting them inside code blocks or inline literals.",
+        "homepage": "https://github.com/adamtheturtle/vale-style-clear-prose",
+        "url": "https://github.com/adamtheturtle/vale-style-clear-prose/releases/latest/download/ClearProse.zip",
+        "logo": "https://github.com/adamtheturtle.png",
+        "tags": [
+            "style"
+        ]
+    },
+    {
         "name": "Elastic",
         "description": "Elastic Docs' style guide rules for the Vale linter.",
         "homepage": "https://github.com/elastic/vale-rules",


### PR DESCRIPTION
Adds [ClearProse](https://github.com/adamtheturtle/vale-style-clear-prose), a small style package for reStructuredText.

It contains one rule, `ClearProse.NoEmDash`, which reports the Unicode em dash (U+2014) as an error in prose.

## Relationship to existing packages

`RedHat.EmDash` already prohibits em dashes, so it is worth saying where this differs rather than leaving you to find out.

That rule sets `scope: raw`, so it matches the source text rather than the parsed document. In reStructuredText that means it reports em dashes inside code blocks and inline literals. Run against this package's fixtures, it reports 14 alerts in the two files that hold em dashes in code, where `ClearProse.NoEmDash` reports none. It is also a warning rather than an error, and it arrives as one rule among 37 in a style guide written for Red Hat documentation.

`Google.EmDash` and `Microsoft.Dashes` match `\s[—–]\s` and ask for the spaces to be closed up. They permit the em dash itself, so neither conflicts with this rule.

## Checks

Run locally before opening this:

- `pytest tests` passes (valid JSON, alphabetical order, required keys, working `homepage` and `url`).
- The verification step passes: `ClearProse.zip` downloads from `releases/latest`, contains a single `ClearProse/` directory, and loads into Vale with exit 0.

The archive is built reproducibly by a release workflow and is byte-identical across the release assets and a local build. The package repository has its own CI that runs fixture tests against a pinned Vale, and is MIT licensed.
